### PR TITLE
storage sheepdog: allow to specify redundancy level

### DIFF
--- a/docs/schemas/storagevol.rng
+++ b/docs/schemas/storagevol.rng
@@ -55,6 +55,9 @@
         <element name='allocation'>
           <ref name='scaledInteger'/>
         </element>
+        <element name='redundancy'>
+          <ref name='string'/>
+        </element>
       </optional>
     </interleave>
   </define>

--- a/src/conf/storage_conf.c
+++ b/src/conf/storage_conf.c
@@ -1345,6 +1345,8 @@ virStorageVolDefParseXML(virStoragePoolDefPtr pool,
         ret->target.allocation = ret->target.capacity;
     }
 
+    ret->target.redundancy = virXPathString("string(./redundancy)", ctxt);
+
     ret->target.path = virXPathString("string(./target/path)", ctxt);
     if (options->formatFromString) {
         char *format = virXPathString("string(./target/format/@type)", ctxt);

--- a/src/util/virstoragefile.c
+++ b/src/util/virstoragefile.c
@@ -1846,7 +1846,8 @@ virStorageSourceCopy(const virStorageSource *src,
         VIR_STRDUP(ret->backingStoreRaw, src->backingStoreRaw) < 0 ||
         VIR_STRDUP(ret->snapshot, src->snapshot) < 0 ||
         VIR_STRDUP(ret->configFile, src->configFile) < 0 ||
-        VIR_STRDUP(ret->compat, src->compat) < 0)
+        VIR_STRDUP(ret->compat, src->compat) < 0 ||
+        VIR_STRDUP(ret->redundancy, src->redundancy) < 0)
         goto error;
 
     if (src->nhosts) {
@@ -2040,6 +2041,7 @@ virStorageSourceClear(virStorageSourcePtr def)
     VIR_FREE(def->volume);
     VIR_FREE(def->snapshot);
     VIR_FREE(def->configFile);
+    VIR_FREE(def->redundancy);
     virStorageSourcePoolDefFree(def->srcpool);
     VIR_FREE(def->driverName);
     virBitmapFree(def->features);

--- a/src/util/virstoragefile.h
+++ b/src/util/virstoragefile.h
@@ -282,6 +282,8 @@ struct _virStorageSource {
     /* Name of the child backing store recorded in metadata of the
      * current file.  */
     char *backingStoreRaw;
+    /* redundancy level, may be used by sheepdog or ceph */
+    char *redundancy;
 };
 
 

--- a/tests/storagevolxml2xmlin/vol-sheepdog.xml
+++ b/tests/storagevolxml2xmlin/vol-sheepdog.xml
@@ -4,6 +4,7 @@
   </source>
   <capacity unit='bytes'>1024</capacity>
   <allocation unit='bytes'>0</allocation>
+  <redundancy unit='string'>3</redundancy>
   <target>
     <path>sheepdog:test2</path>
   </target>

--- a/tests/storagevolxml2xmlout/vol-sheepdog.xml
+++ b/tests/storagevolxml2xmlout/vol-sheepdog.xml
@@ -4,6 +4,7 @@
   </source>
   <capacity unit='bytes'>1024</capacity>
   <allocation unit='bytes'>0</allocation>
+  <redundancy unit='string'>3</redundancy>
   <target>
     <path>sheepdog:test2</path>
     <format type='unknown'/>


### PR DESCRIPTION
Some storage backends allows to specify per volume redundancy options.
Sheepdog use x format for specify copies, and x:y format to specify
data and parity block count.

Signed-off-by: Alexey Tyabin <aleksey.tyabin@gmail.com>
Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>