### PR TITLE
Loopback is 'lo0' on most non-linux OSes

### DIFF
--- a/src/network/bridge_driver.c
+++ b/src/network/bridge_driver.c
@@ -1002,7 +1002,12 @@ networkDnsmasqConfContents(virNetworkObjPtr network,
         virBufferAsprintf(&configbuf, "pid-file=%s\n", pidfile);
 
     /* dnsmasq will *always* listen on localhost unless told otherwise */
+#ifdef __linux__
     virBufferAddLit(&configbuf, "except-interface=lo\n");
+#else
+    /* BSD family OSes and Solaris call loopback interface as lo0 */
+    virBufferAddLit(&configbuf, "except-interface=lo0\n");
+#endif
 
     if (dnsmasqCapsGet(caps, DNSMASQ_CAPS_BIND_DYNAMIC)) {
         /* using --bind-dynamic with only --interface (no


### PR DESCRIPTION
There is no way to change default dnsmasq options in libvirtd.
Try to adapt libvirt dnsmasq for non-linux operating systems where loopback interface is usually called 'lo0', not just 'lo'.