### PR TITLE
libvirt-guests: Ensure managed save directory stays mounted

### DIFF
--- a/tools/libvirt-guests.service.in
+++ b/tools/libvirt-guests.service.in
@@ -2,6 +2,7 @@
 Description=Suspend/Resume Running libvirt Guests
 Wants=libvirtd.service
 Requires=virt-guest-shutdown.target
+RequiresMountsFor=/var/lib/libvirt/qemu/save
 After=network.target
 After=time-sync.target
 After=libvirtd.service


### PR DESCRIPTION
If /var/lib/libvirt/qemu/save is a separate mount point, it gets unmounted before the guests are saved, and then mounted over at boot so the saved images are not accessible and there probably wasn't enough space to save them.  I believe this should handle this case.