### PR TITLE
Add check for mon->msg in qemuMonitorSend

### DIFF
--- a/src/qemu/qemu_monitor.c
+++ b/src/qemu/qemu_monitor.c
@@ -1071,7 +1071,7 @@ qemuMonitorSend(qemuMonitorPtr mon,
           "mon=%p msg=%s fd=%d",
           mon, mon->msg->txBuffer, mon->msg->txFD);
 
-    while (!mon->msg->finished) {
+    while (mon->msg && !mon->msg->finished) {
         if (virCondWait(&mon->notify, &mon->parent.lock) < 0) {
             virReportError(VIR_ERR_INTERNAL_ERROR, "%s",
                            _("Unable to wait on monitor condition"));


### PR DESCRIPTION
Found a coredump on src host when a vm is  migrated(after EVENT_SUSPENDED is occured), I think there is a risk.
the stack looks like:
#0  qemuMonitorSend (mon=mon@entry=0x7f35380415d0, msg=msg@entry=0x7f36001997d0) at qemu/qemu_monitor.c:1036
#1  0x00007f35b3637bb0 in qemuMonitorJSONCommandWithFd (mon=mon@entry=0x7f35380415d0, cmd=cmd@entry=0x7f3588172fc0, 
    scm_fd=scm_fd@entry=-1, reply=reply@entry=0x7f3600199860) at qemu/qemu_monitor_json.c:300
#2  0x00007f35b363abd1 in qemuMonitorJSONCommand (reply=0x7f3600199860, cmd=0x7f3588172fc0, mon=0x7f35380415d0)
    at qemu/qemu_monitor_json.c:330
#3  qemuMonitorJSONGetAllBlockStatsInfo (mon=mon@entry=0x7f35380415d0, hash=0x7f358812d9b0, 
    backingChain=backingChain@entry=false) at qemu/qemu_monitor_json.c:2080
#4  0x00007f35b3625a8e in qemuMonitorGetAllBlockStatsInfo (mon=0x7f35380415d0, ret_stats=ret_stats@entry=0x7f3600199928, 
    backingChain=backingChain@entry=false) at qemu/qemu_monitor.c:2238
#5  0x00007f35b3659d3f in qemuDomainBlocksStatsGather (driver=driver@entry=0x7f35881a3060, vm=0x7f3524020e80, 
    path=0x7f35881155f0 "vda", retstats=retstats@entry=0x7f3600199998) at qemu/qemu_driver.c:10561
#6  0x00007f35b365a4f5 in qemuDomainBlockStats (dom=<optimized out>, path=<optimized out>, stats=0x7f3600199a20)
    at qemu/qemu_driver.c:10618
#7  0x00007f360f4e7e30 in virDomainBlockStats (dom=dom@entry=0x7f3588165c10, disk=0x7f35881155f0 "vda", 
    stats=stats@entry=0x7f3600199b20, size=size@entry=40) at libvirt-domain.c:5416
#8  0x00007f361036d5b4 in remoteDispatchDomainBlockStats (server=0x7f3611410ac0, msg=0x7f3611464360, ret=0x7f358812aa70, 
    args=0x7f35882b7780, rerr=0x7f3600199c50, client=<optimized out>) at remote_dispatch.h:4081
#9  remoteDispatchDomainBlockStatsHelper (server=0x7f3611410ac0, client=<optimized out>, msg=0x7f3611464360, 
    rerr=0x7f3600199c50, args=0x7f35882b7780, ret=0x7f358812aa70) at remote_dispatch.h:4055
#10 0x00007f360f55a722 in virNetServerProgramDispatchCall (msg=0x7f3611464360, client=0x7f3611462810, server=0x7f3611410ac0, 
    prog=0x7f361145def0) at rpc/virnetserverprogram.c:437
#11 virNetServerProgramDispatch (prog=0x7f361145def0, server=server@entry=0x7f3611410ac0, client=0x7f3611462810, 
    msg=0x7f3611464360) at rpc/virnetserverprogram.c:307
#12 0x00007f3610383afd in virNetServerProcessMsg (msg=<optimized out>, prog=<optimized out>, client=<optimized out>, 
    srv=0x7f3611410ac0) at rpc/virnetserver.c:148
#13 virNetServerHandleJob (jobOpaque=<optimized out>, opaque=0x7f3611410ac0) at rpc/virnetserver.c:169
#14 0x00007f360f43f431 in virThreadPoolWorker (opaque=opaque@entry=0x7f3611405320) at util/virthreadpool.c:167
#15 0x00007f360f43e7b8 in virThreadHelper (data=<optimized out>) at util/virthread.c:206
#16 0x00007f360c85ddc5 in start_thread () from /lib64/libpthread.so.0
#17 0x00007f360c58b21d in clone () from /lib64/libc.so.6