### PR TITLE
conf: Don't parse edev of non-passthrough input device

### DIFF
--- a/src/conf/domain_conf.c
+++ b/src/conf/domain_conf.c
@@ -13050,7 +13050,8 @@ virDomainInputDefParseXML(virDomainXMLOptionPtr xmlopt,
         goto error;
     }
 
-    if ((evdev = virXPathString("string(./source/@evdev)", ctxt)))
+    if ((evdev = virXPathString("string(./source/@evdev)", ctxt)) &&
+        (def->type == VIR_DOMAIN_INPUT_TYPE_PASSTHROUGH))
         def->source.evdev = virFileSanitizePath(evdev);
     if (def->type == VIR_DOMAIN_INPUT_TYPE_PASSTHROUGH && !def->source.evdev) {
         virReportError(VIR_ERR_XML_ERROR, "%s",


### PR DESCRIPTION
In input devices, edev attribute is only for passthrough devices.
Don't parse this for other input devices.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1591151

Signed-off-by: Han Han <hhan@redhat.com>