### PR TITLE
add phytium 2000plus and s2500 support on arm architecture.

### DIFF
--- a/src/cpu_map/arm_Phytium.xml
+++ b/src/cpu_map/arm_Phytium.xml
@@ -1,0 +1,10 @@
+<cpus>
+  <model name='phytium-2000plus'>
+    <vendor name='Phytium'/>
+    <pvr value='0x662'/>
+  </model>
+  <model name='phytium-s2500'>
+    <vendor name='Phytium'/>
+    <pvr value='0x663'/>
+  </model>
+</cpus>

--- a/src/cpu_map/arm_vendors.xml
+++ b/src/cpu_map/arm_vendors.xml
@@ -11,4 +11,5 @@
   <vendor name='Qualcomm' value='0x51'/>
   <vendor name='Marvell' value='0x56'/>
   <vendor name='Intel' value='0x69'/>
+  <vendor name='Phytium' value='0x70'/>
 </cpus>

--- a/src/cpu_map/index.xml
+++ b/src/cpu_map/index.xml
@@ -103,5 +103,8 @@
 
     <!-- Hisilicon-based CPU models -->
     <include filename='arm_Kunpeng-920.xml'/>
+
+	<!-- Phytium-based CPU models -->
+	<include filename='arm_Phytium.xml'/>
   </arch>
 </cpus>


### PR DESCRIPTION
add phytium chip(2000plus and s2500) support on arm architeture. 
Phytium Technology Co., Ltd.