### PR TITLE
fix:repair of command injection

### DIFF
--- a/scripts/meson-dist.py
+++ b/scripts/meson-dist.py
@@ -2,13 +2,14 @@
 
 import os
 import sys
+import subprocess
 
 meson_build_root = sys.argv[1]
 file_name = sys.argv[2]
 
 meson_dist_root = os.environ['MESON_DIST_ROOT']
 
-os.system('cp {0} {1}'.format(
+subprocess.call(['cp',
     os.path.join(meson_build_root, file_name),
     os.path.join(meson_dist_root, file_name)
-))
+])


### PR DESCRIPTION
the function os.system used in meson-dist.py could be attacked by command injection, which whill result in serious consequences.Using subprocess.call instead could implements the same function and protects against this attack.In this project, meson dist.py is used as the code for project compilation and construction, and does not exist in the runtime environment, making it difficult for attackers to invade. Therefore, this patch mainly prevents potential hazards and extreme hacker attacks that users may encounter during use, enhancing the stability of the code.

 Signed-off-by: unknown <u202012145@hust.edu.cn>