### PR TITLE
src/rpc: Add 'GPG_TTY' and "TERM" environment variables

### DIFF
--- a/src/rpc/virnetsocket.c
+++ b/src/rpc/virnetsocket.c
@@ -843,6 +843,8 @@ int virNetSocketNewConnectSSH(const char *nodename,
     virCommandAddEnvPass(cmd, "OPENSSL_CONF");
     virCommandAddEnvPass(cmd, "DISPLAY");
     virCommandAddEnvPass(cmd, "XAUTHORITY");
+    virCommandAddEnvPass(cmd, "GPG_TTY");
+    virCommandAddEnvPass(cmd, "TERM");
     virCommandClearCaps(cmd);
 
     if (service)


### PR DESCRIPTION
Add  "TERM" environment variable to avoid the problem "TERM environment variable not set".Add 'GPG_TTY' environment variable to hold the path to the TTY device for the interactive shell.