### PR TITLE
virt-aa-helper: allow riscv64 EDK II

### DIFF
--- a/src/security/virt-aa-helper.c
+++ b/src/security/virt-aa-helper.c
@@ -481,6 +481,7 @@ valid_path(const char *path, const bool readonly)
         "/usr/share/AAVMF/",
         "/usr/share/qemu-efi/",              /* for AAVMF images */
         "/usr/share/qemu-efi-aarch64/",
+        "/usr/share/qemu-efi-riscv64/",
         "/usr/share/qemu/",                  /* SUSE path for OVMF and AAVMF images */
         "/usr/lib/u-boot/",
         "/usr/lib/riscv64-linux-gnu/opensbi",


### PR DESCRIPTION
Debian has packaged EDK II for 64-bit RISC-V in directory /usr/share/qemu-efi-riscv64/.

For usage with libvirt update the apparmor helper.