### PR TITLE
vmx: Add support for parsing vTPM devices

### DIFF
--- a/src/vmx/vmx.c
+++ b/src/vmx/vmx.c
@@ -599,6 +599,7 @@ static int virVMXParseSerial(virVMXContext *ctx, virConf *conf, int port,
 static int virVMXParseParallel(virVMXContext *ctx, virConf *conf, int port,
                                virDomainChrDef **def);
 static int virVMXParseSVGA(virConf *conf, virDomainVideoDef **def);
+static int virVMXParseTPM(virConf *conf, virDomainTPMDef **def);
 
 static int virVMXFormatVNC(virDomainGraphicsDef *def, virBuffer *buffer);
 static int virVMXFormatDisk(virVMXContext *ctx, virDomainDiskDef *def,
@@ -1403,6 +1404,7 @@ virVMXParseConfig(virVMXContext *ctx,
     char *guestOS = NULL;
     bool smbios_reflecthost = false;
     bool uefi_secureboot = false;
+    bool vtpm_present = false;
     int controller;
     int bus;
     int port;
@@ -1938,6 +1940,16 @@ virVMXParseConfig(virVMXContext *ctx,
 
     def->nvideos = 1;
 
+    /* def:tpms */
+    {
+        virDomainTPMDef *tpm = NULL;
+        if (virVMXParseTPM(conf, &tpm) < 0)
+            goto cleanup;
+
+        if (tpm)
+            VIR_APPEND_ELEMENT(def->tpms, def->ntpms, tpm);
+    }
+
     /* def:sounds */
     /* FIXME */
 
@@ -1999,6 +2011,18 @@ virVMXParseConfig(virVMXContext *ctx,
                            firmware);
             goto cleanup;
         }
+    }
+
+    /* vmx: vtpm.present (optional) */
+    if (virVMXGetConfigBoolean(conf, "vtpm.present", 
+        &vtpm_present, false, true) < 0) {
+        virReportError(VIR_ERR_INTERNAL_ERROR,
+                        _("Unable to parse vtpm.present"));
+        goto cleanup;
+    }
+    if (vtpm_present) {
+        VIR_DEBUG("Processing vtpm_present: %s", 
+            (vtpm_present == true) ? "yes" : "no");
     }
 
     /* vmx:uefi.secureBoot.enabled */
@@ -3367,6 +3391,32 @@ virVMXParseSVGA(virConf *conf, virDomainVideoDef **def)
     return result;
 }
 
+static int
+virVMXParseTPM(virConf *conf, virDomainTPMDef **def)
+{
+    bool vtpm_present = false;
+
+    if (def == NULL || *def != NULL) {
+        virReportError(VIR_ERR_INTERNAL_ERROR, "%s", _("Invalid argument"));
+        return -1;
+    }
+
+    /* vmx:vtpm.present */
+    if (virVMXGetConfigBoolean(conf, "vtpm.present", &vtpm_present,
+                               false, true) < 0) {
+        return -1;
+    }
+
+    if (!vtpm_present)
+        return 0;
+
+    *def = g_new0(virDomainTPMDef, 1);
+    (*def)->type = VIR_DOMAIN_TPM_TYPE_EMULATOR;
+    (*def)->model = VIR_DOMAIN_TPM_MODEL_CRB;
+    (*def)->data.emulator.version = VIR_DOMAIN_TPM_VERSION_2_0;
+
+    return 0;
+}
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *

--- a/tests/vmx2xmldata/vtpm.vmx
+++ b/tests/vmx2xmldata/vtpm.vmx
@@ -1,0 +1,22 @@
+config.version = "8"
+virtualHW.version = "19"
+displayName = "test-vtpm"
+memsize = "4096"
+numvcpus = "2"
+guestOS = "windows9-64"
+
+# Disk Configuration
+scsi0.present = "TRUE"
+scsi0.virtualDev = "lsisas1068"
+scsi0:0.present = "TRUE"
+scsi0:0.deviceType = "scsi-hardDisk"
+scsi0:0.fileName = "test_disk.vmdk"
+
+# vTPM configuration
+vtpm.present = "TRUE"
+
+# Network Configuration
+ethernet0.present = "TRUE"
+ethernet0.connectionType = "nat"
+ethernet0.virtualDev = "e1000e"
+ethernet0.addressType = "generated"

--- a/tests/vmx2xmldata/vtpm.xml
+++ b/tests/vmx2xmldata/vtpm.xml
@@ -1,0 +1,32 @@
+<domain type='vmware'>
+  <name>test-vtpm</name>
+  <uuid>00000000-0000-0000-0000-000000000000</uuid>
+  <memory unit='KiB'>4194304</memory>
+  <currentMemory unit='KiB'>4194304</currentMemory>
+  <vcpu placement='static'>2</vcpu>
+  <os>
+    <type arch='x86_64'>hvm</type>
+  </os>
+  <clock offset='utc'/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <devices>
+    <disk type='file' device='disk'>
+      <source file='[datastore] directory/test_disk.vmdk'/>
+      <target dev='sda' bus='scsi'/>
+      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
+    </disk>
+    <controller type='scsi' index='0' model='lsisas1068'/>
+    <interface type='user'>
+      <mac address='00:00:00:00:00:00' type='generated'/>
+      <model type='e1000e'/>
+    </interface>
+    <tpm model='tpm-crb'>
+      <backend type='emulator' version='2.0'/>
+    </tpm>
+    <video>
+      <model type='vmvga' vram='4096' primary='yes'/>
+    </video>
+  </devices>
+</domain>

--- a/tests/vmx2xmltest.c
+++ b/tests/vmx2xmltest.c
@@ -243,6 +243,8 @@ mymain(void)
 
     DO_TEST("firmware-efi");
 
+    DO_TEST("vtpm");
+
     ctx.datacenterPath = "folder1/folder2/datacenter1";
 
     DO_TEST("datacenterpath");


### PR DESCRIPTION
Parse vtpm.present from VMX files and convert to libvirt TPM device
with CRB model and emulator backend. VMware vTPM uses TPM 2.0 with the CRB